### PR TITLE
Fix AuthService reference in order guard

### DIFF
--- a/frontend/docs/orders-review.md
+++ b/frontend/docs/orders-review.md
@@ -1,0 +1,27 @@
+# Revisión módulo `orders`
+
+Se detectaron inconsistencias y oportunidades de mejora en los componentes y servicios bajo `src/app/orders`.
+
+## Problemas encontrados
+
+- **Uso de `AuthService` incorrecto en `order-details.guard.ts`**: se importaba la versión antigua del servicio desde `auth/auth.service` y se utilizaba el método `isAuthenticated()`. Esto podía producir fallos de compilación y comportamiento inconsistente, ya que el resto de la aplicación emplea el servicio ubicado en `core/services`.
+- **Falta de tooling**: el proyecto no incluye scripts de linting/test preconfigurados para ejecutarse sin Angular CLI instalado en producción. Esto dificulta validar los cambios automáticamente.
+
+## Tareas propuestas
+
+1. **Unificar el servicio de autenticación**
+   - Reemplazar todas las importaciones de `../../auth/auth.service` por `../../core/services/auth.service`.
+   - Adaptar llamadas a métodos de autenticación usando la API actual del servicio (`checkStoredToken`, `currentUser`).
+
+2. **Mejorar verificación de autenticación en guards**
+   - Sustituir el uso obsoleto de `isAuthenticated()` por `checkStoredToken()` o validación del token almacenado.
+   - Asegurar que los guards funcionen de manera asíncrona y manejen correctamente los `LoadingController`.
+
+3. **Agregar pruebas unitarias del módulo de órdenes**
+   - Crear `order-details.guard.spec.ts` y otros archivos de prueba para verificar rutas y permisos.
+   - Incluir mocks de servicios (`AuthService`, `OrderService`) para aislar comportamiento.
+
+4. **Documentar flujo de trabajo del módulo**
+   - Mantener un archivo en `frontend/docs/` con guías de uso y notas de mantenimiento del código.
+
+La corrección incluida en este commit aborda el punto 1 para `order-details.guard.ts`.

--- a/frontend/src/app/orders/guards/order-details.guard.ts
+++ b/frontend/src/app/orders/guards/order-details.guard.ts
@@ -13,7 +13,7 @@ import { map, catchError, tap } from 'rxjs/operators';
 import { AlertController, LoadingController } from '@ionic/angular';
 
 import { OrderService } from '../services/order.service';
-import { AuthService } from '../../auth/auth.service';
+import { AuthService } from '../../core/services/auth.service';
 
 @Injectable({
   providedIn: 'root'
@@ -58,8 +58,8 @@ export class OrderDetailsGuard implements CanActivate {
       });
       await loading.present();
 
-      // Verificar autenticación
-      const isAuthenticated = this.authService.isAuthenticated();
+      // Verificar autenticación utilizando el servicio centralizado
+      const isAuthenticated = await this.authService.checkStoredToken();
       if (!isAuthenticated) {
         await loading.dismiss();
         console.error('❌ Usuario no autenticado');


### PR DESCRIPTION
## Summary
- fix order-details guard to use the AuthService from core/services
- document review findings in `orders-review.md`

## Testing
- `npm run lint` *(fails: ng not found)*
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_68409d41bd44832fb4c8ed12f24b7cfb